### PR TITLE
Fix terminal background in dark variant

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -186,7 +186,7 @@ function getTheme({ style, name }) {
       "terminal.ansiBrightMagenta":primer.pink[7],
       "terminal.ansiBrightCyan": primer.blue[7],
       "terminal.ansiBrightWhite": primer.gray[2],
-      "terminal.background": "#f6f3ed",
+      "terminal.background": pick({ light: "#f6f3ed", dark: primer.gray[0] }),
       "terminal.foreground": primer.gray[6],
 
       "gitDecoration.addedResourceForeground": primer.green[5],


### PR DESCRIPTION
From this:
<img width="698" alt="Screenshot 2020-12-20 at 11 58 05" src="https://user-images.githubusercontent.com/428060/102710399-a1c00b80-42ba-11eb-8eaf-818956bc842f.png">

To this:
<img width="715" alt="Screenshot 2020-12-20 at 11 58 56" src="https://user-images.githubusercontent.com/428060/102710416-c87e4200-42ba-11eb-9d00-513c01f722b5.png">
